### PR TITLE
Remove Just Command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -46,10 +46,6 @@ lefthook-validate:
 zizmor-check:
     uvx zizmor . --persona=pedantic
 
-# Run zizmor checking with sarif output
-zizmor-check-sarif:
-    uvx zizmor . --persona=pedantic --format sarif > results.sarif
-
 # ------------------------------------------------------------------------------
 # Pinact
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Description

This pull request simplifies the `Justfile` by removing an unused command related to SARIF output.

Cleanup of unused commands:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL49-L52): Removed the `zizmor-check-sarif` command, which generated SARIF output, as it is no longer needed.