### PR TITLE
Update npm dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,19 @@ updates:
         update-types:
           - "patch"
           - "minor"
+
+  - package-ecosystem: "npm"
+    directory: "website"
+    schedule:
+      interval: "cron"
+      cronjob: "30 7 * * *"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      javascript:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration file to include a new package ecosystem for managing dependencies in the `website` directory. The update introduces a cron-based schedule for dependency updates and adds grouping for JavaScript version updates.

### Dependabot configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R22-R37): Added a new configuration for the `npm` package ecosystem in the `website` directory. This includes a cronjob scheduled at `7:30 AM` (Europe/London timezone) to check for updates on the `main` branch, with support for grouping JavaScript version updates by patterns and update types (`patch` and `minor`).