### PR TITLE
Add uv to Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,16 @@ updates:
         update-types:
           - "patch"
           - "minor"
+
+  - package-ecosystem: "uv"
+    directory: "tests"
+    schedule:
+      interval: "cron"
+      cronjob: "30 7 * * *"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      python:
+        applies-to: "version-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration to add automated dependency updates for the `uv` package ecosystem in the `tests` directory. The new configuration schedules updates using a cron job and groups Python version updates together.

Dependabot configuration enhancements:

* Added a new `uv` package-ecosystem entry for the `tests` directory, enabling automated dependency updates for Python packages in that location.
* Scheduled these updates to run daily at 07:30 (Europe/London timezone) using a cron job.
* Configured grouping for Python version updates, ensuring all related updates are bundled together for easier management.
