### PR TITLE
Update License to Licence

### DIFF
--- a/.github/tool-configurations/labeller.yml
+++ b/.github/tool-configurations/labeller.yml
@@ -21,7 +21,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `labeller.yml` configuration to improve file labeling accuracy for markdown-related files. The main change is a correction to the spelling of the license file in the markdown label configuration.

* Label configuration update:
  * Changed the markdown label pattern from `"LICENSE"` to `"LICENCE"` in `.github/tool-configurations/labeller.yml` to match the actual file name.