### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/actions/setup-test-dependencies/action.yml
+++ b/.github/actions/setup-test-dependencies/action.yml
@@ -11,9 +11,9 @@ runs:
   using: "composite"
   steps:
     - name: Set up Just
-      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         working-directory: tests
     - name: Install Playwright Dependencies

--- a/.github/actions/setup-website-dependencies/action.yml
+++ b/.github/actions/setup-website-dependencies/action.yml
@@ -5,13 +5,13 @@ runs:
   using: "composite"
   steps:
     - name: Set up Node.js with Cache
-      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: "website/package.json"
         cache: "npm"
         cache-dependency-path: "website/package-lock.json"
     - name: Set up Just
-      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
     - name: Install website Dependencies
       shell: bash
       run: just website::install-ci

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -16,6 +16,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@df2f9791faacdfc1e3a041fbbc83e13bfbba1259 # v2026.02.21.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@770e0f8d83d2cf12795ae93c33ff48b731c41201 # v2026.06.30.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         language: [actions, javascript]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@df2f9791faacdfc1e3a041fbbc83e13bfbba1259 # v2026.02.21.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@770e0f8d83d2cf12795ae93c33ff48b731c41201 # v2026.06.30.01
     with:
       language: ${{ matrix.language }}
 
@@ -38,7 +38,7 @@ jobs:
       actions: read # Allow the workflow to read actions metadata
       pull-requests: write # Allow the workflow to create and modify pull request comments
       security-events: write # Allow the workflow to upload analysis results
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@df2f9791faacdfc1e3a041fbbc83e13bfbba1259 # v2026.02.21.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@770e0f8d83d2cf12795ae93c33ff48b731c41201 # v2026.06.30.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -66,7 +66,7 @@ jobs:
       security-events: write # Allow the workflow to upload analysis results
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -81,7 +81,7 @@ jobs:
         run: just website::eslint-with-sarif
         continue-on-error: true
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: website/eslint-results.sarif
           wait-for-processing: true
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -111,7 +111,7 @@ jobs:
       security-events: write # Allow the workflow to upload analysis results
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -124,7 +124,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: tests/ruff-results.sarif
           wait-for-processing: true
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       id-token: write # to allow the workflow to request an ID token
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -34,14 +34,14 @@ jobs:
       - name: Build
         run: just website::build
       - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: "./website/dist"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
   link-tests:
     name: Link Tests
@@ -49,7 +49,7 @@ jobs:
     needs: deploy
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -15,6 +15,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write # For writing labels and comments on PRs
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@df2f9791faacdfc1e3a041fbbc83e13bfbba1259 # v2026.02.21.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@770e0f8d83d2cf12795ae93c33ff48b731c41201 # v2026.06.30.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -20,6 +20,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # For writing labels to the repository
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@df2f9791faacdfc1e3a041fbbc83e13bfbba1259 # v2026.02.21.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@770e0f8d83d2cf12795ae93c33ff48b731c41201 # v2026.06.30.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 # Pre-commit configuration for use with `prek` (https://github.com/j178/prek)
 
-minimum_prek_version: "0.3.0"
+minimum_prek_version: "0.4.0"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: check-merge-conflict
         name: Check Merge Conflicts
@@ -20,26 +20,26 @@ repos:
         name: Detect Private Key
         description: Detects private keys that may have been added to the repository
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.0
+    rev: 83d9cd684c87d95d656c1458ef04895a7f1cbd8e # frozen: v8.30.1
     hooks:
       - id: gitleaks
         name: Gitleaks - Secret Detection
         description: Scan for secrets using Gitleaks
         language_version: "go1.25"
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.11
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca # frozen: v1.7.12
     hooks:
       - id: actionlint
         name: Actionlint
         description: Linter for GitHub Actions workflow files
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
-    rev: 3.6.0
+    rev: bebfac867564fbd992e5b45379b4b0568d5cb85b # frozen: 3.6.1
     hooks:
       - id: editorconfig-checker
         name: EditorConfig Checker
         description: Validates files against .editorconfig rules
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.22.0
+    rev: e3eebf65325ccc992422292cb7a4baee967cf815 # frozen: v1.26.1
     hooks:
       - id: zizmor
         name: Zizmor
@@ -52,7 +52,7 @@ repos:
         language: node
         entry: prettier
         additional_dependencies:
-          - prettier@3.8.1
+          - prettier@3.9.4
         args: ["--check"]
         files: "(?i)(\\.(md|markdown|ya?ml|json)$|^(README|LICENSE|CONTRIBUTING|CODE_OF_CONDUCT|SECURITY|SUPPORT)(\\.md)?$)"
       - id: justfile-format-check
@@ -60,7 +60,7 @@ repos:
         language: python
         entry: just
         additional_dependencies:
-          - rust-just==1.46.0
+          - rust-just==1.55.0
         args: ["format-check"]
         files: "(?i)(^justfile$|\\.just$)"
         pass_filenames: false
@@ -69,7 +69,8 @@ repos:
         language: golang
         entry: pinact
         additional_dependencies:
-          - github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v3.9.0
+          - github.com/suzuki-shunsuke/pinact/v4/cmd/pinact@v4.1.0
         args: ["run", "--verify", "--check"]
         files: "^\\.github/(workflows|actions)/.*\\.ya?ml$|(^|/)action\\.ya?ml$"
         pass_filenames: false
+        language_version: "go1.26.4"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates various dependencies and actions used in CI workflows and pre-commit hooks to their latest versions, ensuring improved security, reliability, and compatibility. The changes primarily focus on upgrading GitHub Actions, reusable workflows, and pre-commit hook versions.

**CI/CD Workflow Updates:**

* Updated all references to `actions/checkout` to version `v7.0.0` in workflow files such as `.github/workflows/code-checks.yml` and `.github/workflows/deploy.yml` for improved performance and features. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L50-R50) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L69-R69) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L96-R96) [[4]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L114-R114) [[5]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L141-R141) [[6]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L155-R155) [[7]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L26-R26) [[8]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L37-R52)
* Upgraded GitHub Actions for configuring and deploying Pages to their latest major versions in `.github/workflows/deploy.yml`.
* Updated the upload-sarif action to `v4.36.2` for both ESLint and Ruff analysis results uploads. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L84-R84) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L127-R127)

**Reusable Workflow and Action Updates:**

* Updated all references to `JackPlowman/reusable-workflows` (e.g., `common-clean-caches.yml`, `codeql-analysis.yml`, `common-code-checks.yml`, `common-pull-request-tasks.yml`, `common-sync-labels.yml`) to version `v2026.06.30.01` for the latest improvements and fixes. [[1]](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL19-R19) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L30-R30) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L41-R41) [[4]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL18-R18) [[5]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L23-R23)
* Upgraded `setup-just`, `setup-uv`, and `actions/setup-node` actions to their latest versions in `.github/actions/setup-test-dependencies/action.yml` and `.github/actions/setup-website-dependencies/action.yml`. [[1]](diffhunk://#diff-ee1e9a84357cfd23d067400706d92b6bb9d8fd8744e81563d9858e8c344df144L14-R16) [[2]](diffhunk://#diff-24c40199d9151f1a7883d7762d9a3f740e2270022992b08acae64e63fa738b1aL8-R14)

**Pre-commit Hook Updates:**

* Increased `minimum_prek_version` to `0.4.0` and updated all pre-commit hooks to their latest versions, including `gitleaks`, `actionlint`, `editorconfig-checker`, `zizmor`, `prettier`, and `rust-just`. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L3-R7) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L23-R42) [[3]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L55-R63)
* Upgraded `pinact` to v4 and set `language_version` to `go1.26.4` for improved workflow file verification.

These updates help keep the project secure and compatible with the latest tooling.