### PR TITLE
Freeze Prek Hooks

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -104,7 +104,7 @@ prek-update:
 
 # Prek update hooks
 prek-update-hooks:
-    prek autoupdate
+    prek autoupdate --force
 
 prek-update-additional-dependencies:
     uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the `Justfile` by adding the `--force` flag to the `prek autoupdate` command in the `prek-update-hooks` recipe. This ensures that the update process proceeds even if there are warnings or prompts that would otherwise require manual intervention.